### PR TITLE
Provide test credentials for sample app

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,19 @@ The Buy SDK includes a comprehensive sample application that covers the SDK's mo
 
 ## Setup [⤴](#table-of-contents)
 
-To run the sample application, you need to provide credentials to the shop that the app will point to:
+To run the sample application, you can import this repository in Android Studio and run the project on a virtual device that you've created in the AVD manager.
+
+### Provide your own credentials
+
+You may choose to provide credentials to the shop that the app will point to:
 
 1. Create a private app with a Storefront API access token to access the storefront data. The storefront access token acts as the API key.
-2. Create `shop.properties` file under the root folder and add next lines:
+2. Modify the file `sample/shop.properties` with your credentials.
     
 ```
 SHOP_DOMAIN=<your-shop-here>.myshopify.com
 API_KEY=<your-api-key>
 ```
-
-3. Install a virtual device using the AVD Manager and run the sample app on that device.
 
 ## Contributions [⤴](#table-of-contents)
 

--- a/sample/shop.properties
+++ b/sample/shop.properties
@@ -1,0 +1,2 @@
+SHOP_DOMAIN=graphql.myshopify.com
+API_KEY=8e2fef6daed4b93cf4e731f580799dd1


### PR DESCRIPTION
# What

Similar to how [we provide sample credentials for the iOS version of this app](https://github.com/Shopify/mobile-buy-sdk-ios-sample/blob/2415520e8d97e05df67b9a69b7813460caeb1a02/Storefront/Client.swift#L34), this PR introduces sample credentials for the graphql.myshopify.com shop.

# How

Add the `shop.properties` file in the right location. It is still in `.gitignore` so that it doesn't get modified by mistake.
