### PR TITLE
Add Shop Pay Button to Cart Activity

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,9 @@ def versions = [
     apolloVersion        : '2.5.9',
     archVersion          : '2.0.0',
     kotlin               : '1.5.20',
-    buySdkVersion        : '5.0.0'
+    buySdkVersion        : '5.0.0',
+    junitVersion         : '1.7.1.1',
+    junitApiVersion      : '5.7.1'
 ]
 
 ext.isCi = "true" == System.getenv('CI')
@@ -54,5 +56,8 @@ ext.dep = [
     rxrelay                  : "com.jakewharton.rxrelay2:rxrelay:2.0.0",
     archComponents           : "androidx.lifecycle:lifecycle-extensions:$versions.archVersion",
     gson                     : "com.google.code.gson:gson:2.8.6",
-    buySdk                   : "com.shopify.mobilebuysdk:buy3:$versions.buySdkVersion"
+    buySdk                   : "com.shopify.mobilebuysdk:buy3:$versions.buySdkVersion",
+    junitPlugin              : "de.mannodermaus.gradle.plugins:android-junit5:$versions.junitVersion",
+    junitRuntime             : "org.junit.jupiter:junit-jupiter-api:$versions.junitApiVersion",
+    junitEngine              : "org.junit.jupiter:junit-jupiter-engine:$versions.junitApiVersion",
 ]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -17,7 +17,7 @@ ext.isCi = "true" == System.getenv('CI')
 ext.androidConfig = [
     compileSdkVersion: 28,
     buildToolsVersion: '30.0.2',
-    minSdkVersion    : 21
+    minSdkVersion    : 24
 ]
 
 ext.dep = [

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     classpath dep.butterknifePlugin
     classpath dep.apolloPlugin
     classpath dep.kotlinPlugin
+    classpath dep.junitPlugin
   }
 }
 
@@ -11,6 +12,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'com.jakewharton.butterknife'
 apply plugin: 'com.apollographql.apollo'
+apply plugin: 'de.mannodermaus.android-junit5'
 
 android {
   compileSdkVersion androidConfig.compileSdkVersion
@@ -109,6 +111,8 @@ dependencies {
   implementation dep.rxJava
   implementation dep.timber
   implementation dep.butterKnife
+  testImplementation dep.junitRuntime
+  testRuntimeOnly dep.junitEngine
   annotationProcessor dep.butterKnifeCompiler
   implementation(dep.fresco) {
     exclude group: 'com.android.support'

--- a/sample/src/main/java/com/shopify/sample/util/ShopPayUriBuilder.java
+++ b/sample/src/main/java/com/shopify/sample/util/ShopPayUriBuilder.java
@@ -1,0 +1,47 @@
+package com.shopify.sample.util;
+
+import android.net.Uri;
+import android.util.Base64;
+
+import androidx.annotation.NonNull;
+
+import com.shopify.sample.domain.model.Checkout;
+
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+
+public class ShopPayUriBuilder {
+    private static final String SHOP_PAY_PAYMENT_PARAM_VALUE = "shop_pay";
+    private static final String PAYMENT_PARAM_KEY = "payment";
+    private static final String CART_PATH = "cart";
+    private static final String HTTPS_SCHEME = "https";
+
+    /**
+     * @param checkout A valid checkout object from which to generate a Shop Pay URI.
+     * @return A URI which can be used to invoke Shop Pay with the contents of the checkout.
+     */
+    public static Uri buildShopPayURI(@NonNull Checkout checkout) {
+        String storeAuthority = Uri.parse(checkout.webUrl).getAuthority();
+        Uri.Builder shopPayBuilder = new Uri.Builder()
+                .scheme(ShopPayUriBuilder.HTTPS_SCHEME)
+                .authority(storeAuthority)
+                .appendPath(ShopPayUriBuilder.CART_PATH)
+                .appendEncodedPath(getVariantSlug(checkout))
+                .appendQueryParameter(ShopPayUriBuilder.PAYMENT_PARAM_KEY, ShopPayUriBuilder.SHOP_PAY_PAYMENT_PARAM_VALUE);
+        return shopPayBuilder.build();
+    }
+
+    protected static String getVariantSlug(@NonNull Checkout checkout) {
+        return checkout.lineItems.stream().map(item -> getDecodedVariantId(item.variantId) + ":" + item.quantity).collect(Collectors.joining(","));
+    }
+
+    protected static String getDecodedVariantId(@NonNull String variantId) {
+        String fullVariantId = new String(Base64.decode(variantId, Base64.DEFAULT), StandardCharsets.UTF_8);
+        String[] variantIds = fullVariantId.split("/");
+        // The expected format of the decoded input is "gid://shopify/ProductVariant/12315116"
+        if (variantIds.length != 5)
+            throw new IllegalArgumentException("Invalid format for input");
+        return variantIds[variantIds.length - 1];
+    }
+}
+

--- a/sample/src/main/java/com/shopify/sample/view/cart/CartActivity.java
+++ b/sample/src/main/java/com/shopify/sample/view/cart/CartActivity.java
@@ -46,13 +46,12 @@ import com.shopify.sample.R;
 import com.shopify.sample.R2;
 import com.shopify.sample.domain.model.Checkout;
 import com.shopify.sample.domain.model.ShopSettings;
+import com.shopify.sample.util.ShopPayUriBuilder;
 import com.shopify.sample.view.ProgressDialogHelper;
 import com.shopify.sample.view.ScreenRouter;
 import com.shopify.sample.view.checkout.CheckoutViewModel;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.List;
 import java.util.stream.Collectors;
 
 import butterknife.BindView;
@@ -236,30 +235,8 @@ public final class CartActivity extends AppCompatActivity {
   }
 
   private void onShopPayCheckoutConfirmation(final Checkout checkout) {
-    Uri shopPayUri = buildShopPayURI(checkout);
     CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder().build();
-    customTabsIntent.launchUrl(this, shopPayUri);
-  }
-
-  private Uri buildShopPayURI(Checkout checkout) {
-    String storeAuthority = Uri.parse(checkout.webUrl).getAuthority();
-    Uri.Builder shopPayBuilder = new Uri.Builder()
-            .scheme("https")
-            .authority(storeAuthority)
-            .appendPath("cart")
-            .appendEncodedPath(getVariantSlug(checkout))
-            .appendQueryParameter("payment", "shop_pay");
-    return shopPayBuilder.build();
-  }
-
-  private String getVariantSlug(Checkout checkout) {
-    return checkout.lineItems.stream().map(item -> getDecodedVariantId(item.variantId) + ":" + item.quantity).collect(Collectors.joining(","));
-  }
-
-  private String getDecodedVariantId(String variantId) {
-    String fullVariantId = new String(Base64.decode(variantId, Base64.DEFAULT), StandardCharsets.UTF_8);
-    List<String> elements = Arrays.asList(fullVariantId.split("/"));
-    return elements.get(elements.size() - 1);
+    customTabsIntent.launchUrl(this, ShopPayUriBuilder.buildShopPayURI(checkout));
   }
 
   private void showError(final int requestId, final Throwable t, final String message) {

--- a/sample/src/main/java/com/shopify/sample/view/cart/CartDetailsViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/cart/CartDetailsViewModel.java
@@ -36,12 +36,15 @@ import java.util.UUID;
 public interface CartDetailsViewModel extends ViewModel {
   int REQUEST_ID_UPDATE_CART = UUID.randomUUID().hashCode();
   int REQUEST_ID_CREATE_WEB_CHECKOUT = UUID.randomUUID().hashCode();
+  int REQUEST_ID_CREATE_SHOP_PAY_CHECKOUT = UUID.randomUUID().hashCode();
   int REQUEST_ID_CREATE_ANDROID_PAY_CHECKOUT = UUID.randomUUID().hashCode();
   int REQUEST_ID_PREPARE_ANDROID_PAY = UUID.randomUUID().hashCode();
 
   void onGoogleApiClientConnectionChanged(boolean connected);
 
   LifeCycleBoundCallback<Checkout> webCheckoutCallback();
+
+  LifeCycleBoundCallback<Checkout> shopPayCheckoutCallback();
 
   LifeCycleBoundCallback<CartDetailsViewModel.AndroidPayCheckout> androidPayCheckoutCallback();
 

--- a/sample/src/main/java/com/shopify/sample/view/cart/CartHeaderView.java
+++ b/sample/src/main/java/com/shopify/sample/view/cart/CartHeaderView.java
@@ -109,6 +109,10 @@ public final class CartHeaderView extends FrameLayout implements LifecycleOwner 
     viewModel.webCheckout();
   }
 
+  @OnClick(R2.id.shop_pay) void onShopPayCheckoutClick() {
+    viewModel.shopPayCheckout();
+  }
+
   @OnClick(R2.id.android_pay_checkout) void onAndroidPayCheckoutClick() {
     viewModel.androidPayCheckout();
   }

--- a/sample/src/main/java/com/shopify/sample/view/cart/CartHeaderViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/cart/CartHeaderViewModel.java
@@ -38,4 +38,6 @@ public interface CartHeaderViewModel {
   void webCheckout();
 
   void androidPayCheckout();
+
+  void shopPayCheckout();
 }

--- a/sample/src/main/java/com/shopify/sample/view/cart/RealCartViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/cart/RealCartViewModel.java
@@ -55,6 +55,7 @@ public final class RealCartViewModel extends BaseViewModel implements CartDetail
   private final CartWatchInteractor cartWatchInteractor = new RealCartWatchInteractor();
   private final CheckoutCreateInteractor checkoutCreateInteractor = new RealCheckoutCreateInteractor();
   private final LifeCycleBoundCallback<Checkout> webCheckoutCallback = new LifeCycleBoundCallback<>();
+  private final LifeCycleBoundCallback<Checkout> shopPayCheckoutCallback = new LifeCycleBoundCallback<>();
   private final LifeCycleBoundCallback<Cart> androidPayStartCheckoutCallback = new LifeCycleBoundCallback<>();
   private final LifeCycleBoundCallback<AndroidPayCheckout> androidPayCheckoutCallback = new LifeCycleBoundCallback<>();
   private final MutableLiveData<Cart> cartLiveData = new MutableLiveData<>();
@@ -84,6 +85,11 @@ public final class RealCartViewModel extends BaseViewModel implements CartDetail
     createCheckout(REQUEST_ID_CREATE_ANDROID_PAY_CHECKOUT, cartLiveData.getValue());
   }
 
+  @Override
+  public void shopPayCheckout() {
+    createCheckout(REQUEST_ID_CREATE_SHOP_PAY_CHECKOUT, cartLiveData.getValue());
+  }
+
   @Override public LiveData<Boolean> googleApiClientConnectionData() {
     return googleApiClientConnectionData;
   }
@@ -99,6 +105,11 @@ public final class RealCartViewModel extends BaseViewModel implements CartDetail
   @Override public LifeCycleBoundCallback<Checkout> webCheckoutCallback() {
     return webCheckoutCallback;
   }
+
+  @Override public LifeCycleBoundCallback<Checkout> shopPayCheckoutCallback() {
+    return shopPayCheckoutCallback;
+  }
+
 
   @Override public LifeCycleBoundCallback<AndroidPayCheckout> androidPayCheckoutCallback() {
     return androidPayCheckoutCallback;
@@ -143,6 +154,7 @@ public final class RealCartViewModel extends BaseViewModel implements CartDetail
   private void createCheckout(final int requestId, final Cart cart) {
     cancelRequest(REQUEST_ID_CREATE_WEB_CHECKOUT);
     cancelRequest(REQUEST_ID_CREATE_ANDROID_PAY_CHECKOUT);
+    cancelRequest(REQUEST_ID_CREATE_SHOP_PAY_CHECKOUT);
 
     if (cart == null) return;
 
@@ -170,6 +182,8 @@ public final class RealCartViewModel extends BaseViewModel implements CartDetail
       webCheckoutCallback.notify(checkout);
     } else if (requestId == REQUEST_ID_CREATE_ANDROID_PAY_CHECKOUT) {
 //      androidPayStartCheckoutCallback.notify(payCart = checkoutPayCart(checkout));
+    } else if (requestId == REQUEST_ID_CREATE_SHOP_PAY_CHECKOUT) {
+      shopPayCheckoutCallback.notify(checkout);
     }
   }
 

--- a/sample/src/main/res/layout/cart_header.xml
+++ b/sample/src/main/res/layout/cart_header.xml
@@ -70,4 +70,13 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/title2" />
 
+    <Button
+        android:id="@+id/shop_pay"
+        android:layout_width="160dp"
+        android:layout_height="48dp"
+        android:layout_marginTop="@dimen/default_padding"
+        android:text="@string/shop_pay"
+        android:backgroundTint="@color/shop_pay_primary"
+        app:layout_constraintStart_toStartOf="@+id/web_checkout"
+        app:layout_constraintTop_toBottomOf="@+id/web_checkout" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/values/colors.xml
+++ b/sample/src/main/res/values/colors.xml
@@ -3,4 +3,5 @@
     <color name="colorPrimary">#0A0A0B</color>
     <color name="text_grey">#6c6c6c</color>
     <color name="snackbar_error_background">#ff0e0e</color>
+    <color name="shop_pay_primary">#5a31f4</color>
 </resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -27,4 +27,5 @@
     <string name="checkout_complete_progress">Confirming Order …</string>
     <string name="checkout_shipping_select_shipping_rate">Please select shipping method</string>
     <string name="checkout_success">Your order has been placed successfully</string>
+    <string name="shop_pay">Shop Pay</string>
 </resources>

--- a/sample/src/test/java/android/util/Base64.java
+++ b/sample/src/test/java/android/util/Base64.java
@@ -1,0 +1,7 @@
+package android.util;
+
+public class Base64 {
+    public static byte[] decode(String str, int flags) {
+        return java.util.Base64.getDecoder().decode(str);
+    }
+}

--- a/sample/src/test/java/com/shopify/sample/util/ShopPayUriBuilderTest.java
+++ b/sample/src/test/java/com/shopify/sample/util/ShopPayUriBuilderTest.java
@@ -1,0 +1,38 @@
+package com.shopify.sample.util;
+
+import com.shopify.sample.domain.model.Checkout;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ShopPayUriBuilderTest {
+    @org.junit.jupiter.api.Test
+    void test_getVariantSlug() {
+        final Checkout.ShippingRates rates = new Checkout.ShippingRates(true, Arrays.asList());
+        final Checkout.ShippingRate singleRate = new Checkout.ShippingRate("", BigDecimal.ONE, "");
+
+        // Starting with one item, one quantity.
+        List<Checkout.LineItem> oneItem =
+                Arrays.asList(new Checkout.LineItem("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMjMxNTExNg", "Good stuff", 1, BigDecimal.ONE));
+        Checkout oneItemCheckout = new Checkout("id", "https://store.com/checkout/12314151", "USD", true, oneItem, rates, singleRate, BigDecimal.ONE, BigDecimal.ONE, BigDecimal.ONE);
+        assertEquals("12315116:1", ShopPayUriBuilder.getVariantSlug(oneItemCheckout));
+
+        // Having more items and more quantities.
+        List<Checkout.LineItem> twoItems =
+                Arrays.asList(
+                        new Checkout.LineItem("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMjMxNTExNg", "Good stuff", 3, BigDecimal.ONE),
+                        new Checkout.LineItem("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMjM0NTY3Njc", "Good stuff 2", 2, BigDecimal.ONE));
+        Checkout twoItemCheckout = new Checkout("id", "https://store.com/checkout/12314151", "USD", true, twoItems, rates, singleRate, BigDecimal.ONE, BigDecimal.ONE, BigDecimal.ONE);
+        assertEquals("12315116:3,123456767:2", ShopPayUriBuilder.getVariantSlug(twoItemCheckout));
+    }
+
+    @org.junit.jupiter.api.Test
+    void test_getDecodedVariantId() {
+        assertEquals("12315116", ShopPayUriBuilder.getDecodedVariantId("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMjMxNTExNg"));
+        assertThrows(java.lang.IllegalArgumentException.class, () -> ShopPayUriBuilder.getDecodedVariantId(""));
+    }
+}


### PR DESCRIPTION
## What

Using [`Checkout Links powered by Shop Pay`](https://help.shopify.com/en/manual/products/details/checkout-link) functionality, adding an example of how someone might create a Shop Pay button in their Android app using the mobile buy SDK.

## How

- Constructed a Checkout Link powered by Shop Pay (also called cart permalink) using the variants and quantities. 
- Used `ChromeCustomTabs` to open a webview to the Shop Pay Uri that was constructed.
- Bumped the API level to 24 (Android 7 from 4-5 years ago) to use new Java Stream/Lambda goodness. It can probably also be done without.

## Video

https://user-images.githubusercontent.com/499162/127496020-62851c02-8fd0-4ea4-8756-a68b9630c542.mp4




